### PR TITLE
Implements guard against partial state loss with accounts

### DIFF
--- a/CF Apps/Data/CFAccountStore.swift
+++ b/CF Apps/Data/CFAccountStore.swift
@@ -16,9 +16,12 @@ class CFAccountStore {
     class func create(account: CFAccount) throws {
         do {
             try account.createInSecureStore()
-            saveKey(account.account)
         } catch LocksmithError.Duplicate {
             try account.updateInSecureStore()
+        }
+        
+        if !exists(account.username, target: account.target) {
+            saveKey(account.account)
         }
     }
     

--- a/CF AppsTests/Data/CFAccountStoreTests.swift
+++ b/CF AppsTests/Data/CFAccountStoreTests.swift
@@ -40,6 +40,27 @@ class CFAccountStoreTests: XCTestCase {
         XCTAssertEqual(list[0].account, testAccountKey)
     }
     
+    func testAccountCreateExisting() {
+        try! CFAccountStore.create(testAccount!)
+        
+        NSUserDefaults.standardUserDefaults().removeObjectForKey(CFAccountStore.accountListKey)
+        
+        try! CFAccountStore.create(testAccount!)
+        
+        let list = CFAccountStore.list()
+        XCTAssertEqual(list.count, 1)
+        XCTAssertEqual(list[0].account, testAccountKey)
+    }
+    
+    func testDuplicateCreate() {
+        try! CFAccountStore.create(testAccount!)
+        try! CFAccountStore.create(testAccount!)
+        
+        let list = CFAccountStore.list()
+        XCTAssertEqual(list.count, 1)
+        XCTAssertEqual(list[0].account, testAccountKey)
+    }
+    
     func testAccountRead() {
         try! CFAccountStore.create(testAccount!)
         


### PR DESCRIPTION
Uninstalling the application gets rid of NSUserDefaults but objects in the Keystore can persist which results in a partial loss of state. This allows the application to recover.
